### PR TITLE
07 basket

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,20 +7,28 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Item from './components/Item';
 import ErrorPage from './components/ErrorPage';
 import ItemRoll from './components/ItemRoll';
+import Checkout from './components/Checkout';
+import { BasketContext } from './contexts/BasketContext';
+import { useState } from 'react';
 
 function App() {
+  const [ basket, setBasket ] = useState([])
+
   return (
     <BrowserRouter>
-    <div className="App">
-      <Header />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/shop" element={<ItemRoll />} />
-        <Route path="/shop/:num" element={<Item />} />
-        <Route path="/*" element={<ErrorPage errorType={404} />} />
-      </Routes>
-      <Footer />
-    </div>
+      <BasketContext.Provider value={{ basket, setBasket }}>
+        <div className="App">
+          <Header />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/shop" element={<ItemRoll />} />
+            <Route path="/shop/:num" element={<Item />} />
+            <Route path="/checkout" element={<Checkout />} />
+            <Route path="/*" element={<ErrorPage errorType={404} />} />
+          </Routes>
+          <Footer />
+        </div>
+      </BasketContext.Provider>
     </BrowserRouter>
   );
 }

--- a/src/components/BasketPopOut.jsx
+++ b/src/components/BasketPopOut.jsx
@@ -1,0 +1,42 @@
+import React, { useContext } from 'react';
+import '../stylesheets/BasketPopOut.css';
+import { BasketContext } from '../contexts/BasketContext';
+
+export default function BasketPopOut({ display }) {
+    const { basket, setBasket } = useContext(BasketContext);
+    const displayClass = display === true ? "fadeOut" : "" ;
+
+    const basketPrice = basket.reduce((a,b) => {return a + (b.price * b.quantity)}, 0);
+    const basketQuantity = basket.reduce((a,b) => {return a + b.quantity}, 0);
+
+    function BasketItem({ item }) {
+        return (
+            <section className='basketSection basketPacer'>
+                <span id='imgHolder'>
+                    <img src={require(`../assets/${item.img_url}.jpg`)} />
+                </span>
+                <p>{item.name} (x{item.quantity})</p>
+                <p>£{(item.price * item.quantity).toFixed(2)} </p>
+            </section>
+        )
+    }
+
+    if (basket.length === 0) return (
+        <div id="BasketPopOut">
+            <p id="basketEmpty" className='basketPacer'>
+                Your basket is currently empty.
+            </p>
+        </div>
+      )
+
+  return (
+    <div id="BasketPopOut" className={`${displayClass}`}>
+        <p className='basketPacer'>Your Basket:</p>
+        {basket.map( i => <BasketItem item={i} key={i.id}/>)}
+        <section id="basketEnd" className='basketPacer'>
+            <p>Total:</p> 
+            <p id="basketTotal">£{basketPrice.toFixed(2)}</p>
+        </section>
+    </div>
+  )
+}

--- a/src/components/Checkout.jsx
+++ b/src/components/Checkout.jsx
@@ -1,0 +1,73 @@
+import React, { useContext, useState } from 'react'
+import { Link } from 'react-router-dom';
+import { BasketContext } from '../contexts/BasketContext'
+import '../stylesheets/Checkout.css'
+
+export default function Checkout() {
+    const { basket, setBasket } = useContext(BasketContext)
+    const [ alertWindow, setAlertWindow ] = useState(true);
+
+    const basketPrice = basket.reduce((a,b) => {return a + (b.price * b.quantity)}, 0);
+    const basketQuantity = basket.reduce((a,b) => {return a + b.quantity}, 0);
+
+    function removeItem(i) {
+        const newBasket = i.quantity <= 1 ?
+        basket.filter((e)=>{
+            if (e.id !== i.id) return e
+        })
+        :
+        basket.map((e)=>{
+            if (e.id !== i.id) return e
+            else {
+                i.quantity--
+                return i
+            }
+        })
+        setBasket(newBasket);
+    }
+
+    function BasketItem({ item }) {
+        return (
+            <section className='checkoutItem'>
+                <img src={require(`../assets/${item.img_url}.jpg`)} />
+                <p>{item.name}</p>
+                <p>{item.quantity} in basket (£{item.price} each)</p>
+                <p>£{(item.price * item.quantity).toFixed(2)} </p>
+                <span id='removalLink' onClick={()=>removeItem(item)}>
+                    Remove from basket
+                </span>
+            </section>
+        )
+    }
+
+    if (basket.length === 0) return (
+        <div id="Checkout">
+            <p id="checkoutEmpty">
+                Your basket is currently empty.
+            </p>
+        </div>
+      )
+
+    function preventConfusion() {
+        if (!alertWindow) return;
+        setAlertWindow(false);
+        alert("This is a demo website with no payment methods built in. Clicking this button will direct to an error page only.")
+    }
+
+  return (
+    <div id="Checkout">
+        Your Basket ({basketQuantity} total items):
+        {basket.map( i => <BasketItem item={i} key={i.id}/>)}
+        <section id="checkoutEnd">
+            <p>Total:</p> 
+            <p id="checkoutTotal">£{basketPrice.toFixed(2)}</p>
+            <br />
+            <Link to={"/errorpage"} >
+                <button onMouseOver={()=>preventConfusion()}>
+                    Proceed
+                </button>
+            </Link>
+        </section>
+    </div>
+  )
+}

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,17 +1,54 @@
 import data from '../data/placeholder.json';
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import '../stylesheets/Item.css'
 import { useParams } from 'react-router-dom';
 import ErrorPage from './ErrorPage';
+import { BasketContext } from '../contexts/BasketContext';
+import BasketPopOut from './BasketPopOut';
 
 export default function Item() {
+    const { basket, setBasket } = useContext(BasketContext);
+    const [ popOut, setPopOut ] = useState(false);
+    const [ popOutFade, setPopOutFade ] = useState(false);
     const location = useParams();
     const item = data[location.num];
+
+    function previewBasket() {
+      setPopOut(true);
+      setTimeout(()=>{
+        setPopOutFade(true)
+        setTimeout(()=>{
+          setPopOut(false);
+          setPopOutFade(false);
+        }, 500);
+      }, 1500);
+    }
+
+    function addToBasket(e) {
+      e.target.disabled = true;
+      const existingItemNum = basket.filter((i)=>{return i.id === item.id}).length;
+
+      if (existingItemNum === 0) { setBasket([
+        ...basket,
+        {
+          ...item,
+          quantity: 1,
+        }
+      ])} else {
+        const newBasket = [...basket];
+        const index = basket.findIndex((i)=>i.id === item.id);
+        newBasket[index].quantity++;
+        setBasket(newBasket)
+      }
+      e.target.disabled = false;
+      previewBasket();
+    }
 
     if (item === undefined) return <ErrorPage errorType={404} />
 
   return (
     <div id="Item">
+      {popOut ? <BasketPopOut display={popOutFade}/> : null}
       <section id="itemContainer">
         <h1>
           {item.name}
@@ -24,7 +61,7 @@ export default function Item() {
           £{item.price.toFixed(2)}
         </p>
         <p>
-          <button>
+          <button onClick={(e)=>{addToBasket(e)}}>
             Add to Basket
           </button>
         </p>

--- a/src/components/ItemRoll.jsx
+++ b/src/components/ItemRoll.jsx
@@ -10,12 +10,12 @@ function ItemSection(props) {
 
     return (
         <span className='ItemSection'>
-            <Link to={`/shop/${id}`} >
+            <Link to={`/shop/${data[id].id}`} >
                 <img src={require(`../assets/${data[id].img_url}.jpg`)} 
                 alt="this item"/>
             </Link>
             <p>
-                <Link to={`/shop/${id}`} >{ data[id].name }</Link>
+                <Link to={`/shop/${data[id].id}`} >{ data[id].name }</Link>
             </p>
             <p>£{ data[id].price.toFixed(2) }</p>
         </span>

--- a/src/contexts/BasketContext.jsx
+++ b/src/contexts/BasketContext.jsx
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const BasketContext = createContext();

--- a/src/stylesheets/BasketPopOut.css
+++ b/src/stylesheets/BasketPopOut.css
@@ -1,0 +1,72 @@
+#BasketPopOut {
+    width: 200px;
+    height: fit-content;
+    border: 1px solid black;
+    background-color: white;
+
+    position: absolute;
+    right: 10vw;
+    top: 80px;
+    font-size: 12pt;
+    animation: fade 500ms;
+}
+#BasketPopOut.fadeOut {
+    opacity: 0.1;
+    transition-duration: 500ms;
+}
+
+@keyframes fade {
+    0% {
+        opacity: 0;
+    }    
+    100% {
+        opacity: 1;
+    }
+}
+
+#basketEmpty {
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.basketPacer {
+    margin-left: 10px;
+    margin-right: 10px;
+}
+
+.basketSection {
+    width: 180px;
+    display: grid;
+    grid-template-columns: auto auto;
+    margin-bottom: 10px;
+}
+
+#imgHolder {
+    width: 100%;
+    height: 100px;
+}
+img {
+    width: 100%;
+    height: 100%;
+}
+
+.basketSection p:nth-child(2) {
+    margin: 5px 0px 0px 0px;
+    text-align: left;
+}
+.basketSection p:nth-child(3) {
+    margin: 5px 0px 0px 0px;
+    text-align: right;
+}
+.basketSection span {
+    grid-column: span 2;
+}
+
+#basketEnd {
+    display: grid;
+    grid-template-columns: auto auto;
+}
+#basketEnd p:last-child {
+    font-weight: bold;
+    text-align: right;
+}

--- a/src/stylesheets/Checkout.css
+++ b/src/stylesheets/Checkout.css
@@ -1,0 +1,92 @@
+#Checkout {
+    width: 80vw;
+    max-width: 800px;
+    height: fit-content;
+    margin: 40px auto 0px auto;
+
+    /* overflow: hidden; */
+}
+
+.checkoutItem {
+    height: 300px;
+    margin: 20px auto 0px auto;
+    border: 1px solid black;
+    padding: 20px;
+
+    display: grid;
+    grid-template-columns: 48% 48%;
+    gap: 4%;
+}
+
+.checkoutItem img {
+    grid-row: span 4;
+    height: 100%;
+    width: 100%;
+}
+
+.checkoutItem p {
+    margin: auto 0px auto 0px;
+}
+.checkoutItem p:first-of-type {
+    margin-bottom: 0px;
+    font-size: 36pt;
+}
+.checkoutItem p:nth-of-type(2) {
+    margin-top: 0px;
+    font-size: 16pt;
+}
+.checkoutItem p:last-of-type {
+    text-align: right;
+    font-size: 30pt;
+}
+#removalLink {
+    color: gray;
+    text-decoration: underline;
+    font-size: 8pt;
+    text-align: right;
+    width: fit-content;
+    height: fit-content;
+    margin-left: auto;
+}
+#removalLink:hover {
+    cursor: pointer;
+}
+
+
+#checkoutEnd {
+    width: 300px;
+    height: 80px;
+    margin-left: auto;
+    margin-top: 20px;
+
+    display: grid;
+    grid-template-columns: 20% 80%;
+    grid-template-rows: auto auto;
+}
+
+#checkoutTotal {
+    margin: 0pt;
+    font-size: 26pt;
+    text-align: right;
+}
+
+#checkoutEnd a {
+    margin-left: auto;
+}
+
+#checkoutEnd button {
+    width: 200px;
+    height: 50px;
+    margin-left: auto;
+    font-size: 18pt;
+    border: 2px solid black;
+    border-radius: 5px;
+}
+
+#checkoutEmpty {
+    text-align: center;
+    font-size: 32pt;
+    min-height: fit-content;
+    padding: auto 0px auto 0px;
+    line-height: 6;
+}


### PR DESCRIPTION
The 'Add to Basket' button on item pages now adds to a context.
Press also creates a brief popout window displaying the basket.
Added checkout page where basket can be viewed, items removed, and a button to continue.
(Also added a warning when hovering the button to clarify there is no payment link for the demo).

Fixed a bug where using category view caused links to use their index number and not their item number (ie 3rd in list always linking to item id 3).